### PR TITLE
Allow pinning Versio version

### DIFF
--- a/install/action.yml
+++ b/install/action.yml
@@ -4,7 +4,11 @@ author: 'Charlie Ozinga <ozchaz@gmail.com>'
 branding:
   icon: play-circle
   color: black
-inputs: {}
+inputs:
+  version:
+    description: 'Version of Versio to install, using Github release identifier, like "tags/TAG_NAME" or "RELEASE_ID"'
+    required: false
+    default: 'latest'
 
 outputs:
   versio:
@@ -19,6 +23,8 @@ runs:
       shell: bash
     - run: ${{ github.action_path }}/install.sh
       shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
     - run: cp ${{ github.action_path }}/cargo-name $HOME/bin/cargo-name
       shell: bash
     - run: cp ${{ github.action_path }}/cargo-version $HOME/bin/cargo-version

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,10 +1,13 @@
+release_identifier=$INPUT_VERSION
+
 apt-get update && apt-get install -y curl
 
-latest_url=`\
-  curl -sL https://api.github.com/repos/chaaz/versio/releases/latest \
+versio_binary_url=`\
+  curl -sL https://api.github.com/repos/chaaz/versio/releases/${release_identifier} \
   | jq -r '.assets[] | select(.browser_download_url | contains("linux-gnu")) | .browser_download_url'`
 
-curl -L $latest_url -o $HOME/bin/versio
+
+curl -L $versio_binary_url -o $HOME/bin/versio
 chmod a+x $HOME/bin/versio
 
 # Also install rq


### PR DESCRIPTION
I'm not sure about the parameter name, is `version` or is more `relase_indentifier`?
It currently supports tags and release id, but I'm not sure the latter is useful, so maybe just hardcode the `tags` string?